### PR TITLE
infrastructure-maintenance/DOIT-1643 - Retrieve Docker Hub images from ACR Cache

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM rrcfesc/lamp:7.2
+FROM medtrainer.azurecr.io/rrcfesc/lamp:7.2
 
 LABEL maintainer="rruiz@medtrainer.com"
 


### PR DESCRIPTION
This PR adds the medtrainer.azurecr.io prefix to all Docker Hub images in Dockerfiles.